### PR TITLE
fix: change separator in megamenu title

### DIFF
--- a/tools/actions/convert/test/fixtures/header-semantic.html
+++ b/tools/actions/convert/test/fixtures/header-semantic.html
@@ -38,22 +38,22 @@
         <li><a href="/us/en/quote-cart.html">:chat-bubble-left-ellipsis-icon: Quote</a></li>
       </ul>
       <hr>
-      <p><a href="/us/en/solutions/mabs.html">Menu:Solutions:Monoclonal Antibody (MAbs)</a></p>
+      <p><a href="/us/en/solutions/mabs.html">Menu|Solutions|Monoclonal Antibody (MAbs)</a></p>
       <ul>
         <li><a href="/us/en/solutions/mabs/cell-line-development.html">Cell Line Development</a></li>
       </ul>
       <hr>
-      <p><a href="/us/en/solutions/mrna-therapy.html">Menu:Solutions:mRNA Development</a></p>
+      <p><a href="/us/en/solutions/mrna-therapy.html">Menu|Solutions|mRNA Development</a></p>
       <ul>
         <li><a href="/us/en/solutions/mrna-therapy/mrna-development-manufacturing.html">mRNA Development and Manufacturing</a></li>
       </ul>
       <hr>
-      <p><a href="/us/en/solutions/oligonucleotide-therapy.html">Menu:Solutions:Oligonucleotide Therapy</a></p>
+      <p><a href="/us/en/solutions/oligonucleotide-therapy.html">Menu|Solutions|Oligonucleotide Therapy</a></p>
       <ul>
         <li><a href="/us/en/solutions/oligonucleotide-therapy/antisense-oligonucleotide-development-manufacturing.html">Antisense Oligonucleotide Development and Manufacturing</a></li>
       </ul>
       <hr>
-      <p>Menu:Solutions</p>
+      <p>Menu|Solutions</p>
       <ul>
         <li><a href="/us/en/solutions/mabs.html">Monoclonal Antibody (MAbs) :arrow-right:</a></li>
         <li><a href="/us/en/solutions/mrna-therapy.html">mRNA Development :arrow-right:</a></li>
@@ -63,7 +63,7 @@
         <li><a href="/us/en/solutions/gene-therapy.html">Gene Therapy</a></li>
       </ul>
       <hr>
-      <p>Menu:Applications</p>
+      <p>Menu|Applications</p>
       <ul>
         <li><a href="/us/en/application/antisense-oligonucleotides.html">Antisense Oligonucleotides</a></li>
         <li><a href="/us/en/application/elisa.html">ELISA</a></li>
@@ -74,7 +74,7 @@
         <li><a href="/us/en/application/high-throughput-screening-drug-discovery.html">Ultra High Throughput Screening</a></li>
       </ul>
       <hr>
-      <p><a href="/us/en/products.html">Menu:Products</a></p>
+      <p><a href="/us/en/products.html">Menu|Products</a></p>
       <ul>
         <li><a href="/us/en/products/assay-kits.html">Assay Kits</a></li>
         <li><a href="/us/en/products/capillary-electrophoresis-systems.html">Capillary Electrophoresis Systems</a></li>
@@ -96,7 +96,7 @@
         <li><a href="/us/en/products/software-platforms.html">Software Platforms</a></li>
       </ul>
       <hr>
-      <p>Menu:Resources</p>
+      <p>Menu|Resources</p>
       <ul>
         <li><a href="/us/en/blog.html">Blog</a></li>
         <li><a href="/us/en/news.html">News</a></li>

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -304,7 +304,7 @@ const createMenuRecursive = (main, document, menuData, skipItems, parentTitle, p
       return;
     }
     let menuItemTitle = menuItem.name || menuItem.text;
-    const menuItemId = `${parentTitle}:${menuItemTitle}`;
+    const menuItemId = `${parentTitle}|${menuItemTitle}`;
     const listItem = document.createElement('li');
     if (menuItem.links?.length > 0) {
       menuItem.items = menuItem.links;


### PR DESCRIPTION
The colon (`:`) char is used by html pipeline to create <span> elements. Hence it's not appropriate to be used as separator for menu title. Changed to `|` char for separator.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://feat-6-separator--danaher-ls-aem--hlxsites.hlx.page/
