### PR TITLE
fix: open cloud logo links in now tab

### DIFF
--- a/blocks/logo-clouds/logo-clouds.js
+++ b/blocks/logo-clouds/logo-clouds.js
@@ -28,6 +28,7 @@ function styleRowForRightContainer(row) {
   const anchor = row.querySelector('a');
   anchor.className = '';
   anchor.innerHTML = '';
+  anchor.setAttribute('target', '_blank');
   anchor.appendChild(row.firstElementChild);
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #123

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.live/
- After: https://fix-123-lc-links--danaher-ls-aem--hlxsites.hlx.live/
