### PR TITLE
Removed buildHeroBlock from script JS

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -197,6 +197,7 @@ export function setCookie(cname, cvalue, expTime = 30 * 1000 * 60 * 60 * 24, pat
  * Builds hero block and prepends to main in a new section.
  * @param {Element} main The container element
  */
+// eslint-disable-next-line no-unused-vars
 function buildHeroBlock(main) {
   const h1 = main.querySelector('h1');
   const picture = main.querySelector('picture');
@@ -238,7 +239,6 @@ async function loadFonts() {
  */
 function buildAutoBlocks(main) {
   try {
-    buildHeroBlock(main);
     buildVideo(main);
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/
- After: https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/blog
- After: https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/blog/antisense-oligonucleotides-manufacturing-advances
- After: https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/news
- After: https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/news/new-system-fully-integrates-icief-uv-and-mass-spectrometry
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/library
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/library/organoids
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/application
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/application/antisense-oligonucleotides
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/products/centrifuges
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/products/centrifuges/analytical-ultracentrifuges
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/products/assay-kits/topics
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/products/assay-kits/topics/how-are-assay-kits-installed
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/info
- https://bug-disable-autoBlockHero--danaher-ls-aem--hlxsites.hlx.page/us/en/info/what-is-luminescence
