### PR TITLE
fix: adjust object fit for opco card images

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -41,6 +41,7 @@
 }
 
 .cards.opco .cards-card-image img {
+  object-fit: contain;
   transform: scale(1);
   transition: all .6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -614,6 +614,8 @@
 }
 
 .cards.opco .cards-card-image img {
+  -o-object-fit: contain;
+     object-fit: contain;
   transform: scale(1);
   transition: all .6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/us/en/products
- After: https://572-image-styles--danaher-ls-aem--hlxsites.hlx.page/us/en/products
