### PR TITLE
removing metadata for default product page

### DIFF
--- a/tools/importer/transformers/metadata.js
+++ b/tools/importer/transformers/metadata.js
@@ -58,6 +58,10 @@ const addCategoryMeta = (url, meta) => {
   }
 };
 
+const isDefaultProductPage = (url) => {
+  return url.pathname.match(/\/content\/danaher\/ls\/us\/en\/products\/product-coveo/);
+};
+
 const addSKUMeta = (url, meta) => {
   // detect family|sku|budle pages based on url and set sku metadata
   if (url.pathname.match(/\/content\/danaher\/ls\/us\/en\/products\/(family\/|sku\/|bundle\/)/)) {
@@ -68,6 +72,9 @@ const addSKUMeta = (url, meta) => {
 
 // eslint-disable-next-line no-unused-vars
 const createMetadata = (main, document, html, params, urlStr) => {
+
+  if(isDefaultProductPage(urlStr)) return;
+
   const meta = {};
 
   const title = document.querySelector('title');

--- a/tools/importer/transformers/metadata.js
+++ b/tools/importer/transformers/metadata.js
@@ -58,9 +58,7 @@ const addCategoryMeta = (url, meta) => {
   }
 };
 
-const isDefaultProductPage = (url) => {
-  return url.pathname.match(/\/content\/danaher\/ls\/us\/en\/products\/product-coveo/);
-};
+const isDefaultProductPage = (url) => url.pathname.match(/\/content\/danaher\/ls\/us\/en\/products\/product-coveo/);
 
 const addSKUMeta = (url, meta) => {
   // detect family|sku|budle pages based on url and set sku metadata
@@ -72,8 +70,7 @@ const addSKUMeta = (url, meta) => {
 
 // eslint-disable-next-line no-unused-vars
 const createMetadata = (main, document, html, params, urlStr) => {
-
-  if(isDefaultProductPage(urlStr)) return;
+  if (isDefaultProductPage(urlStr)) return;
 
   const meta = {};
 

--- a/tools/importer/transformers/metadata.js
+++ b/tools/importer/transformers/metadata.js
@@ -70,7 +70,7 @@ const addSKUMeta = (url, meta) => {
 
 // eslint-disable-next-line no-unused-vars
 const createMetadata = (main, document, html, params, urlStr) => {
-  if (isDefaultProductPage(urlStr)) return;
+  if (isDefaultProductPage(urlStr)) return {};
 
   const meta = {};
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #681 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://681-default-prod-pages-no-aem-metadata--danaher-ls-aem--hlxsites.hlx.page/
