### PR TITLE
954 [Products] Mini-teasers UI without description field

### DIFF
--- a/blocks/mini-teasers/mini-teasers.js
+++ b/blocks/mini-teasers/mini-teasers.js
@@ -17,6 +17,7 @@ export default function decorate(block) {
       pEl.classList.add(...'line-clamp-3 h-20 break-words'.split(' '));
       pEl.title = pEl.textContent;
     }
+    if (pEl.firstElementChild !== null) pEl?.parentNode?.firstElementChild?.classList.remove('h-20');
     const link = element.querySelector('a');
     if (link) {
       link.parentNode.classList.add('pt-4');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #954 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://954-mini-teasers-issue--danaher-ls-aem--hlxsites.hlx.page/us/en/products
- After: https://954-mini-teasers-issue--danaher-ls-aem--hlxsites.hlx.page/us/en/new-homepage
