### PR TITLE
[UE] pass-through converter: rewrite images

### DIFF
--- a/component-filters.json
+++ b/component-filters.json
@@ -2,8 +2,7 @@
   {
     "id": "main",
     "components": [
-      "section",
-      "breadcrumb"
+      "section"
     ]
   },
   {
@@ -22,6 +21,7 @@
   {
     "id": "section",
     "components": [
+      "breadcrumb",
       "text",
       "image",
       "button",

--- a/tools/actions/convert/test/pass-through/simple-converted.html
+++ b/tools/actions/convert/test/pass-through/simple-converted.html
@@ -8,6 +8,12 @@
       <p><a href="/path/to/page/">/path/to/page/</a></p>
       <p><a href="/path/to/page.html">/path/to/page.html</a></p>
       <p><a href="https://www.adobe.com/path/to/page">https://www.adobe.adobeaemcloud.com/path/to/page</a></p>
+      <p>
+        <img src="https://author-dummy.adobeaemcloud.com/path/to/image.png" alt="">
+      </p>
+      <p>
+        <img src="https://www.adobe.com/path/to/image.png" alt="">
+      </p>
       <div class="metadata">
         <div>
           <div>canonical</div>

--- a/tools/actions/convert/test/pass-through/simple-pass-through.html
+++ b/tools/actions/convert/test/pass-through/simple-pass-through.html
@@ -8,6 +8,8 @@
 <div><a href="/path/to/page/">/path/to/page/</a></div>
 <div><a href="/path/to/page.html">/path/to/page.html</a></div>
 <div><a href="https://www.adobe.com/path/to/page">https://www.adobe.adobeaemcloud.com/path/to/page</a></div>
+<div><img src="https://author-dummy.adobeaemcloud.com/path/to/image.png"></div>
+<div><img src="https://www.adobe.com/path/to/image.png"></div>
 
 
 </body></html>

--- a/tools/actions/convert/test/pass-through/simple.html
+++ b/tools/actions/convert/test/pass-through/simple.html
@@ -10,5 +10,7 @@
 <div><a href="/path/to/page/">/path/to/page/</a></div>
 <div><a href="/path/to/page.html">/path/to/page.html</a></div>
 <div><a href="https://www.adobe.com/path/to/page">https://www.adobe.adobeaemcloud.com/path/to/page</a></div>
+<div><img src="/path/to/image.png"/></div>
+<div><img src="https://www.adobe.com/path/to/image.png"/></div>
 </body>
 </html>


### PR DESCRIPTION
- externalize image references so that the Helix Admin can generate image blobs

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-images--danaher-ls-aem--hlxsites.hlx.page/
