### PR TITLE
[UE] support navigation title

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -175,7 +175,7 @@
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
                   "name": "Recent Articles",
-                  "filter": "recent-articles"
+                  "model": "recent-articles"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -80,8 +80,9 @@
           },
           {
             "component": "text",
-            "name": "FullCategory",
-            "label": "FullCategory"
+            "valueType": "string",
+            "name": "navTitle",
+            "label": "Navigation Title"
           }
         ]
       }


### PR DESCRIPTION
- add navigation title to the page metadata

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-navtitle--danaher-ls-aem--hlxsites.hlx.page/
