### PR TITLE
[UE] use metadata created with the new UI 

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -8,16 +8,17 @@
     "/content/dam/danaher/franklin/metadata.json:/metadata.json",
     "/content/dam/danaher/franklin/metadata-products.json:/metadata-products.json",
     "/content/dam/danaher/franklin/metadata-articles.json:/metadata-articles.json",
-    "/content/danaher/ls/metadata1:/metadata1.json",
     "/content/dam/danaher/franklin/redirects.json:/redirects.json",
     "/content/danaher.resource/us/en/article-index.json:/us/en/article-index.json",
     "/content/danaher.resource/fragments/header/master.plain.html:/fragments/header/master.plain.html",
-    "/content/danaher.resource/fragments/footer.html:/fragments/footer.html"
+    "/content/danaher.resource/fragments/footer.html:/fragments/footer.html",
+    "/content/danaher/ls/metadata:/metadata.json"
   ],
   "includes": [
     "/content/danaher/ls/us/en",
     "/content/danaher/ls/configuration",
     "/content/experience-fragments/danaher/us/en/site",
-    "/content/dam/danaher/franklin"
+    "/content/dam/danaher/franklin",
+    "/content/danaher/ls/metadata"
   ]
 }

--- a/paths.json
+++ b/paths.json
@@ -8,6 +8,7 @@
     "/content/dam/danaher/franklin/metadata.json:/metadata.json",
     "/content/dam/danaher/franklin/metadata-products.json:/metadata-products.json",
     "/content/dam/danaher/franklin/metadata-articles.json:/metadata-articles.json",
+    "/content/danaher/ls/metadata1:/metadata1.json",
     "/content/dam/danaher/franklin/redirects.json:/redirects.json",
     "/content/danaher.resource/us/en/article-index.json:/us/en/article-index.json",
     "/content/danaher.resource/fragments/header/master.plain.html:/fragments/header/master.plain.html",


### PR DESCRIPTION
AEM has support for editing site metadata:
https://author-p93411-e849602.adobeaemcloud.com/content/danaher/ls/metadata.html
From now on site metadata should be handled this way.  Once validated, we can remove the metadata.json file in DAM at `/content/dam/danaher/franklin/metadata.json`.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-metadata--danaher-ls-aem--hlxsites.hlx.page/
