### PR TITLE
[UE] manage metadata from AEM UI

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -12,13 +12,13 @@
     "/content/danaher.resource/us/en/article-index.json:/us/en/article-index.json",
     "/content/danaher.resource/fragments/header/master.plain.html:/fragments/header/master.plain.html",
     "/content/danaher.resource/fragments/footer.html:/fragments/footer.html",
-    "/content/danaher/ls/metadata.json:/metadata.json"
+    "/content/danaher/ls/metadata:/metadata.json"
   ],
   "includes": [
     "/content/danaher/ls/us/en",
     "/content/danaher/ls/configuration",
     "/content/experience-fragments/danaher/us/en/site",
     "/content/dam/danaher/franklin",
-    "/content/danaher/ls/metadata.json"
+    "/content/danaher/ls/metadata"
   ]
 }


### PR DESCRIPTION
- adapt path mapping without .json extension

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-metadata-3--danaher-ls-aem--hlxsites.hlx.page/
