### PR TITLE
[UE] manage metadata from AEM UI

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -8,9 +8,14 @@ mappings:
   - /content/dam/danaher/franklin/metadata-products.json:/metadata-products.json
   - /content/dam/danaher/franklin/metadata-articles.json:/metadata-articles.json
   - /content/dam/danaher/franklin/redirects.json:/redirects.json
+  - /content/danaher.resource/us/en/article-index.json:/us/en/article-index.json
+  - /content/danaher.resource/fragments/header/master.plain.html:/fragments/header/master.plain.html
+  - /content/danaher.resource/fragments/footer.html:/fragments/footer.html
+  - /content/danaher/ls/metadata:/metadata.json
 
 includes:
   - /content/danaher/ls/us/en
   - /content/danaher/ls/configuration
   - /content/experience-fragments/danaher/us/en/site
   - /content/dam/danaher/franklin
+  - /content/danaher/ls/metadata


### PR DESCRIPTION
- adapt path mapping in paths.yaml as it is still used in the converter

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-metadata-4--danaher-ls-aem--hlxsites.hlx.page/
