### PR TITLE
[UE] migrate blog pages

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -82,13 +82,6 @@
             "valueType": "string",
             "name": "navTitle",
             "label": "Navigation Title"
-          },
-          {
-            "component": "text",
-            "valueType": "string",
-            "name": "template",
-            "label": "Template (temporary)",
-            "description": "Until we get the metadata spreadsheet fixed"
           }
         ]
       }

--- a/tools/actions/convert/src/index.js
+++ b/tools/actions/convert/src/index.js
@@ -104,6 +104,7 @@ function skipConverter(path) {
   if (!path) return false;
   if (path.includes('-jck1')) return true;
   if (path.includes('/en-new')) return true;
+  if (path.includes('/us/en/blog/')) return true;
   // skip the converter for pages like **/products/*/topics/**
   const regex = /\/[^/]+\/[^/]+\/products\/[^/]+\/topics-jck1\/[^/]+/;
   return regex.test(path);
@@ -140,7 +141,7 @@ function rewriteImage(image, origin) {
   }
 }
 
-async function rewriteLinks(state) {
+async function rewriteLinksAndImages(state) {
   // eslint-disable-next-line prefer-const
   let { blob, contentType, originUrl } = state;
   let { origin, liveUrls = [] } = converterCfg || {};
@@ -151,36 +152,25 @@ async function rewriteLinks(state) {
 
   if (contentType === 'text/html') {
     const document = domParser(blob, originUrl);
+
+    // rewrite links
     const links = document.querySelectorAll('[href]');
     links.forEach((link) => {
       rewriteLink(link, 'href', origin, liveUrls);
     });
+
+    // rewrite canonical link
     const metaOgUrl = document.querySelector('meta[property="og:url"]');
     if (metaOgUrl) {
       rewriteLink(metaOgUrl, 'content', origin, liveUrls);
     }
-    blob = document.documentElement.outerHTML;
 
-    // eslint-disable-next-line no-param-reassign
-    state = {
-      ...state, originUrl, blob, contentType, contentLength: blob.length,
-    };
-  }
-  return state;
-}
-
-async function rewriteImages(state) {
-  // eslint-disable-next-line prefer-const
-  let { blob, contentType, originUrl } = state;
-  let { origin } = converterCfg || {};
-  origin = new URL(origin);
-
-  if (contentType === 'text/html') {
-    const document = domParser(blob, originUrl);
+    // rewrite images
     const images = document.querySelectorAll('img[src]');
     images.forEach((image) => {
       rewriteImage(image, origin);
     });
+
     blob = document.documentElement.outerHTML;
 
     // eslint-disable-next-line no-param-reassign
@@ -260,8 +250,7 @@ export async function main(params) {
   const pipeline = skipConverter(path)
     ? pipe()
       .use(fetchContentWithFranklinDeliveryServlet)
-      .use(rewriteImages)
-      .use(rewriteLinks)
+      .use(rewriteLinksAndImages)
     : createPipeline();
   if (silent) {
     pipeline.logger = { log: () => {} };


### PR DESCRIPTION
- remove work-around in component model for page meta data
- make the converter pass through the Blog pages

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-blog-migration--danaher-ls-aem--hlxsites.hlx.page/
