### PR TITLE
[UE] migrate News pages

### DIFF
--- a/tools/actions/convert/src/index.js
+++ b/tools/actions/convert/src/index.js
@@ -105,6 +105,7 @@ function skipConverter(path) {
   if (path.includes('-jck1')) return true;
   if (path.includes('/en-new')) return true;
   if (path.includes('/us/en/blog/')) return true;
+  if (path.includes('/us/en/news/')) return true;
   // skip the converter for pages like **/products/*/topics/**
   const regex = /\/[^/]+\/[^/]+\/products\/[^/]+\/topics-jck1\/[^/]+/;
   return regex.test(path);


### PR DESCRIPTION
- make the News pages skip the converter

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1083 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://ue-news-migration--danaher-ls-aem--hlxsites.hlx.page/
