### PR TITLE
1246 [Bug] News Page publishing impacted on prod - blank data

### DIFF
--- a/tools/actions/convert/src/index.js
+++ b/tools/actions/convert/src/index.js
@@ -104,8 +104,8 @@ function skipConverter(path) {
   if (!path) return false;
   if (path.includes('-jck1')) return true;
   if (path.includes('/en-new')) return true;
-  // if (path.includes('/us/en/blog/')) return true;
-  // if (path.includes('/us/en/news/')) return true;
+  if (path.includes('/us/en/blog/')) return true;
+  if (path.includes('/us/en/news/')) return true;
   // skip the converter for pages like **/products/*/topics/**
   const regex = /\/[^/]+\/[^/]+\/products\/[^/]+\/topics-jck1\/[^/]+/;
   return regex.test(path);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1246 

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://1246-blank-news-page--danaher-ls-aem--hlxsites.hlx.page/us/en/news/hands-free-sample-preparation-flow-cytometry
