### PR TITLE
feat: Use CSP for scripts with (cached) nonce + strict-dynamic

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="script-src 'nonce-aem' 'strict-dynamic';"
+        >
         <title>Page not found</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta property="og:title" content="Page not found">
-        <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-        <script type="text/javascript">
+        <script nonce="aem" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+        <script nonce="aem" type="text/javascript">
             window.isErrorPage = true;
             window.errorCode = '404';
         </script>
-        <script type="module">
+        <script nonce="aem" type="module">
             import { sampleRUM } from '/scripts/lib-franklin.js';
             window.addEventListener('load', () => sampleRUM('404', { source: document.referrer, target: window.location.href }));
         </script>

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -30,7 +30,7 @@ export default async function decorate(block) {
       { class: 'flex gap-x-2' },
       li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-linkedin-circle' }))),
       li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&qoute=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
       li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -28,8 +28,8 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
-      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
       li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
       li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -29,8 +29,8 @@ export default async function decorate(block) {
     ul(
       { class: 'flex gap-x-2' },
       li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
-      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
       li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-script-url */
 import {
   a, div, li, p, span, ul,
 } from '../../scripts/dom-builder.js';
@@ -28,11 +27,11 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ onclick: () => window.open(`//www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
-      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
-      li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
-      li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
+      li(a({ href: '#', onclick: () => window.open(`//www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ href: '#', onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
+      li(a({ href: '#', onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ href: '#', onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
+      li(a({ href: '#', onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),
   );
 

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -28,11 +28,11 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ href: 'javascript:window.open("//www.linkedin.com/shareArticle?mini=true&url=" + location.href + "&title=" + document.title)' }, span({ class: 'icon icon-linkedin-circle' }))),
-      li(a({ href: 'javascript:window.open(\'//twitter.com/intent/tweet?\' + location.href + \'&title=\' + encodeURI(document.title))' }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ href: 'javascript:window.open(\'//www.facebook.com/sharer/sharer.php?\' + location.href + \'&title=\' + encodeURI(document.title))' }, span({ class: 'icon icon-facebook-circle' }))),
-      li(a({ href: 'javascript:window.open(\'mailto:?subject=&body=\' + encodeURIComponent(window.location))' }, span({ class: 'icon icon-email-circle' }))),
-      li(a({ href: 'javascript:navigator.clipboard.writeText(window.location.href);' }, span({ class: 'icon icon-clipboard-share-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
+      li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),
   );
 

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -30,7 +30,7 @@ export default async function decorate(block) {
       { class: 'flex gap-x-2' },
       li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-linkedin-circle' }))),
       li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&title=${encodeURI(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&qoute=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
       li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -27,11 +27,11 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ href: '#', onclick: () => window.open(`//www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
-      li(a({ href: '#', onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
-      li(a({ href: '#', onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
-      li(a({ href: '#', onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
-      li(a({ href: '#', onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
+      li(a({ onclick: () => window.open(`//www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
+      li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),
+      li(a({ onclick: () => navigator.clipboard.writeText(window.location.href) }, span({ class: 'icon icon-clipboard-share-circle' }))),
     ),
   );
 

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -28,7 +28,7 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ onclick: () => window.open(`//www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
       li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
       li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),

--- a/blocks/tags-list/tags-list.js
+++ b/blocks/tags-list/tags-list.js
@@ -28,7 +28,7 @@ export default async function decorate(block) {
     p({ class: 'text-base font-bold' }, 'Share'),
     ul(
       { class: 'flex gap-x-2' },
-      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-linkedin-circle' }))),
+      li(a({ onclick: () => window.open(`https://www.linkedin.com/shareArticle?mini=true&url=${window.location.href}&title=${document.title}`) }, span({ class: 'icon icon-linkedin-circle' }))),
       li(a({ onclick: () => window.open(`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&title=${encodeURIComponent(document.title)}`) }, span({ class: 'icon icon-twitter-circle' }))),
       li(a({ onclick: () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`) }, span({ class: 'icon icon-facebook-circle' }))),
       li(a({ onclick: () => window.open(`mailto:?subject=&body=${encodeURIComponent(window.location)}`) }, span({ class: 'icon icon-email-circle' }))),

--- a/head.html
+++ b/head.html
@@ -1,6 +1,7 @@
 <meta
   http-equiv="Content-Security-Policy"
-  content="script-src 'nonce-aem' 'strict-dynamic';"
+  content="script-src 'nonce-aem' 'strict-dynamic'; frame-ancestors 'self' https://*.danaher.com https://danaher.sharepoint.com https://*.decibelinsight.net https://*.decibel.com wss://*.decibelinsight.net; object-src https://www.bioz.com; base-uri 'self';"
+  move-to-head="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script nonce="aem" src="/scripts/lib-franklin.js" type="module"></script>

--- a/head.html
+++ b/head.html
@@ -1,11 +1,15 @@
+<meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic';"
+>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/scripts/lib-franklin.js" type="module"></script>
-<script src="/scripts/dom-builder.js" type="module"></script>
-<script src="/scripts/scripts.js" type="module"></script>
+<script nonce="aem" src="/scripts/lib-franklin.js" type="module"></script>
+<script nonce="aem" src="/scripts/dom-builder.js" type="module"></script>
+<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
 <link rel="preconnect" href="https://danaherls.scene7.com">
 <link rel="dns-prefetch" href="https://danaherls.scene7.com">
 <link rel="stylesheet" href="/styles/styles.css"/>
-<script type="application/ld+json" data-name="website">
+<script nonce="aem" type="application/ld+json" data-name="website">
 {
   "@context": "https://schema.org",
   "@type": "WebSite",

--- a/head.html
+++ b/head.html
@@ -1,6 +1,6 @@
 <meta
   http-equiv="Content-Security-Policy"
-  content="script-src 'nonce-aem' 'strict-dynamic'; frame-ancestors 'self' https://*.danaher.com https://danaher.sharepoint.com https://*.decibelinsight.net https://*.decibel.com wss://*.decibelinsight.net; object-src https://www.bioz.com; base-uri 'self';"
+  content="script-src 'nonce-aem' 'strict-dynamic';"
   move-to-head="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1"/>


### PR DESCRIPTION
Enable Content Security Policy for scripts using `strict-dynamic` and (cached) nonce.

Note: The CSP doesn't have to be configured using a meta tag. We can also prepend `script-src 'nonce-aem' 'strict-dynamic';` directly into the header configuration. I'm doing it like this, so people can test it out directly on this PR, without affecting the main branch. The `nonce="aem"` on the trusted scripts is required, as well as the small refactoring await from the `javascript:` urls in the social share block (some of the sharing features were broken in production, hopefully I managed to fix them correctly).

The following is our current understanding on what would be the level of protection. 
Of course things can change with research and finding ways to bypass, that's why CSP is always about having it as a last line of defence, rather than your main defence. 🙂

**1. Protected even if the nonce is cached**

✅  `.innerHTML` for XSS
✅  `.outerHTML` for XSS
✅  `.insertAdjecentHTML` for XSS
✅  `.setHTMLUnsafe` for XSS
✅  `eval` / `setTimeout` / `setInterval` / Function for XSS
✅  `javascript:` protocol in the href/src attributes
✅  `location.href` / `location.assign()` / `location.replace` for XSS
✅  attribute event handlers (`onclick`, `onblur`, `onload`, `onerror` etc.) for XSS
✅  stored/reflected XSS
* as long as there is no server side manipulation of the HTML in the customer's CDN
* for meta tag: as long as the XSS doesn't happen before the meta tag

**2. not protected, because the nonce is cached**

❌  `document.write` / `document.writeln` -> because you could get the nonce and use it in the exploit

**3.not protected for other reasons**

❌  `document.createRange().createContextualFragment` -> whether the nonce is cached/known is irrelevant, scripts are always executed with `strict-dynamic`.
❌  `src` attribute of a `<script>` tag created by `document.createElement('script')` /  text content of a `<script>` tag created by `document.createElement('script')` / `import` -> permitted by `strict-dynamic`

**4. not protected by CSPs in general**
Script-less attacks
❌  HTML injection,  DOM clobbering, etc.

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://csp--danaher-ls-aem--hlxsites.hlx.page/
