### PR TITLE
updating converter to include shop home and opco home for prod

### DIFF
--- a/tools/actions/convert/src/index.js
+++ b/tools/actions/convert/src/index.js
@@ -221,6 +221,9 @@ function skipConverter(path) {
 
   */
 
+    if((path.includes('us/en/products.html') || path.includes('us/en/products/brands')) && !path.includes('/topics-jck1/')) {    
+        return true;
+    }
  //This condition check will removed
   if(!converterCfg.internalHost.includes('danaher-ls-aem-prod')) {
     if((path.includes('us/en/products/family') || path.includes('us/en/products/sku') || path.includes('us/en/products/bundle')) && !path.includes('/topics-jck1/')) {


### PR DESCRIPTION
Updating converter to include only shop home and opco home for prod

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://em1-converter-prod-04--danaher-ls-aem--hlxsites.hlx.page/
