### PR TITLE
adding category title in page metadata

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -16,6 +16,13 @@
           {
             "component": "text",
             "valueType": "string",
+            "name": "categoryTitle",
+            "label": "Category Title",
+            "value": ""
+          },
+          {
+            "component": "text",
+            "valueType": "string",
             "name": "description",
             "label": "Description",
             "value": ""
@@ -1367,7 +1374,6 @@
         "name": "opcoBannerHeadingType",
         "label": "Banner Heading Type",
         "required": true,
-        "value": "h1",
         "options": [
           {
             "name": "h1",

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -52,8 +52,8 @@ indices:
     target: /us/en/products-index.json
     properties:
       title:
-        select: head > title
-        value: textContent(el)
+        select: head > meta[name="categoryTitle"]
+        value: attribute(el, "content")
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")

--- a/models/_page-metadata.json
+++ b/models/_page-metadata.json
@@ -17,6 +17,13 @@
             {
               "component": "text",
               "valueType": "string",
+              "name": "categoryTitle",
+              "label": "Category Title",
+              "value": ""
+            },
+            {
+              "component": "text",
+              "valueType": "string",
               "name": "description",
               "label": "Description",
               "value": ""


### PR DESCRIPTION
Adding new page properties attribute as "Category Title" which would be used for the categories title in products-index.json

Test URLs:
- Before: https://main--danaher-ls-aem--hlxsites.hlx.page/
- After: https://em1-category-page-title-v22--danaher-ls-aem--hlxsites.hlx.page/
